### PR TITLE
Includes rk loader for .img release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Download a release from the [releases page](https://github.com/7Ji/orangepi5-arc
      - `xz -cdk < ArchLinuxARM-aarch64-OrangePi5-*.img.xz > /dev/theTargetDisk`
    - partition layout and filesystems are pre-determined and you can't easily change (remember to enlarge the root partition)
    - booting configuration already set and ready to go, just plug in the card and it will boot right into the system
-   - **Rockchip bootloader not included to save space**, it is expected to be installed by yourself on SPI flash beforehand with the tools provided in either OrangePi's Debian/Ubuntu or official Armbian
  - `ArchLinuxARM-aarch64-OrangePi5-*-root.tar.xz`
    - a compressed rootfs archive of stuffs in the above image which you should extract to a partitioned disk
      - `bsdtar -C /mnt/yourMountPoint --acls --xattrs -xvpJf ArchLinuxARM-aarch64-OrangePi5-*-root.tar.xz`


### PR DESCRIPTION
Sticking with the KISS philosophy of Arch Linux, this project never goes one step further on deciding things needed by users, anything included or configured are for the image to be bootable and connectable to network, so users can decide which packages they want and configurations they want after the first boot. And even if that is too much, there is -pkgs.tar  release so users can just pacstrap from ground up like Arch Linux.

On to bootloader, it is not included in .img release as I wanted to give users biggest freedom to decide the allocation of bootloader device, boot device and root device. I made the choice to not include the rk loader as that met my use case: for my OPi5, I used the SPI flash for rk bootloader, and a NVMe drive as boot device and root device, and I wanted 0 byte wasted on my SSD. That was natural, but deemed inconvenient by some, especially those expecting the image would boot just like those WhateverPi / Armbian / etc images previously used by them.

As such, I'm opening this PR as a sort-of voting place. This is marked as draft as actually 0 codes have been added to implement it.

What do you guys think?
@Integral-Tech @DaveWK